### PR TITLE
Add initial Vedic Astrology plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# astroloji
-Bu bir vedik astroloji projesidir.
+# Astroloji
+Bu depo, WordPress icin gelistirilmis **Vedik Astroloji Hesaplayici** eklentisini icermektedir.
+Eklenti dogum bilgilerini kullanarak basit bir astroloji raporu olusturur ve raporlari "astro_report" gonderi turu olarak kaydeder.

--- a/vedic-astroloji-hesaplayici/README.md
+++ b/vedic-astroloji-hesaplayici/README.md
@@ -1,0 +1,2 @@
+# Vedik Astroloji Hesaplayici
+Bu eklenti, WordPress sitenizde vedik astroloji hesaplamalari yapmanizi saglar. Dogum bilgilerini alir ve Python betigi uzerinden temel hesaplamalar yapar.

--- a/vedic-astroloji-hesaplayici/assets/css/admin-style.css
+++ b/vedic-astroloji-hesaplayici/assets/css/admin-style.css
@@ -1,0 +1,2 @@
+/* Yonetici paneli stili */
+.wrap h1 { color: #0073aa; }

--- a/vedic-astroloji-hesaplayici/assets/css/style.css
+++ b/vedic-astroloji-hesaplayici/assets/css/style.css
@@ -1,0 +1,2 @@
+/* Kullanici arayuzu stilleri */
+form { max-width: 400px; }

--- a/vedic-astroloji-hesaplayici/assets/js/admin-script.js
+++ b/vedic-astroloji-hesaplayici/assets/js/admin-script.js
@@ -1,0 +1,2 @@
+// Yonetici paneli JS
+console.log('Vedik astroloji admin aktif');

--- a/vedic-astroloji-hesaplayici/assets/js/script.js
+++ b/vedic-astroloji-hesaplayici/assets/js/script.js
@@ -1,0 +1,2 @@
+// Kullanici arayuzu icin JS
+console.log('Vedic astroloji form yuklendi');

--- a/vedic-astroloji-hesaplayici/includes/admin/admin-menu.php
+++ b/vedic-astroloji-hesaplayici/includes/admin/admin-menu.php
@@ -1,0 +1,12 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+function vah_admin_menu() {
+    add_menu_page('Vedik Astroloji', 'Vedik Astroloji', 'manage_options', 'vedik-astroloji', 'vah_settings_page');
+}
+add_action('admin_menu', 'vah_admin_menu');
+
+function vah_settings_page() {
+    include VAH_PLUGIN_DIR . 'includes/admin/settings-page.php';
+}
+?>

--- a/vedic-astroloji-hesaplayici/includes/admin/logs.php
+++ b/vedic-astroloji-hesaplayici/includes/admin/logs.php
@@ -1,0 +1,8 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+function vah_log($message) {
+    $file = VAH_PLUGIN_DIR . 'logs.txt';
+    error_log(date('Y-m-d H:i:s') . ' ' . $message . "\n", 3, $file);
+}
+?>

--- a/vedic-astroloji-hesaplayici/includes/admin/settings-page.php
+++ b/vedic-astroloji-hesaplayici/includes/admin/settings-page.php
@@ -1,0 +1,16 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+function vah_render_settings_page() {
+    echo '<div class="wrap"><h1>Vedik Astroloji Ayarlar</h1>';
+    echo '<p>Bu sayfada API anahtarlarinizi ve diger ayarlari yapabilirsiniz.</p>';
+    echo '</div>';
+}
+add_action('admin_init', function() {
+    register_setting('vah_options', 'vah_api_key');
+});
+
+function vah_settings_page() {
+    vah_render_settings_page();
+}
+?>

--- a/vedic-astroloji-hesaplayici/includes/admin/shortcode-list.php
+++ b/vedic-astroloji-hesaplayici/includes/admin/shortcode-list.php
@@ -1,0 +1,9 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+function vah_shortcode_list_page() {
+    echo '<div class="wrap"><h1>Kisa Kodlar</h1>';
+    echo '<ul><li>[vedic_astro_form] - Formu gosterir</li></ul>';
+    echo '</div>';
+}
+?>

--- a/vedic-astroloji-hesaplayici/includes/astro-calculator.php
+++ b/vedic-astroloji-hesaplayici/includes/astro-calculator.php
@@ -1,0 +1,16 @@
+<?php
+if (!defined('ABSPATH')) { exit; }
+
+function vah_calculate_astro($date, $time, $place) {
+    $python = escapeshellcmd('python3');
+    $script = escapeshellarg(VAH_PLUGIN_DIR . 'includes/python/astro_calc.py');
+    $args = escapeshellarg($date) . ' ' . escapeshellarg($time) . ' ' . escapeshellarg($place);
+    $command = "$python $script $args";
+    $output = shell_exec($command);
+    $result = json_decode($output, true);
+    if (!$result) {
+        $result = array('error' => 'Calculation failed');
+    }
+    return $result;
+}
+?>

--- a/vedic-astroloji-hesaplayici/includes/form-handler.php
+++ b/vedic-astroloji-hesaplayici/includes/form-handler.php
@@ -1,0 +1,31 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function vah_handle_form() {
+    if (!isset($_POST['vah_form_submitted'])) {
+        return;
+    }
+
+    $name = sanitize_text_field($_POST['name'] ?? '');
+    $email = sanitize_email($_POST['email'] ?? '');
+    $birth_date = sanitize_text_field($_POST['birth_date'] ?? '');
+    $birth_time = sanitize_text_field($_POST['birth_time'] ?? '');
+    $birth_place = sanitize_text_field($_POST['birth_place'] ?? '');
+
+    $result = vah_calculate_astro($birth_date, $birth_time, $birth_place);
+
+    $post_id = wp_insert_post(array(
+        'post_type' => 'astro_report',
+        'post_title' => $name . ' - ' . current_time('Y-m-d H:i'),
+        'post_content' => print_r($result, true),
+        'post_status' => 'publish'
+    ));
+
+    if ($email && !is_wp_error($post_id)) {
+        wp_mail($email, 'Astroloji Raporunuz', 'Raporunuz hazir.');
+    }
+}
+add_action('init', 'vah_handle_form');
+?>

--- a/vedic-astroloji-hesaplayici/includes/post-types.php
+++ b/vedic-astroloji-hesaplayici/includes/post-types.php
@@ -1,0 +1,22 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+function vah_register_post_type() {
+    $labels = array(
+        'name' => 'Astro Raporlari',
+        'singular_name' => 'Astro Raporu',
+    );
+
+    $args = array(
+        'labels' => $labels,
+        'public' => false,
+        'show_ui' => true,
+        'supports' => array('title', 'editor'),
+    );
+
+    register_post_type('astro_report', $args);
+}
+add_action('init', 'vah_register_post_type');
+?>

--- a/vedic-astroloji-hesaplayici/includes/python/astro_calc.py
+++ b/vedic-astroloji-hesaplayici/includes/python/astro_calc.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import sys, json
+
+def main():
+    if len(sys.argv) < 4:
+        print(json.dumps({'error': 'args'}))
+        return
+    date = sys.argv[1]
+    time = sys.argv[2]
+    place = sys.argv[3]
+    # Placeholder calculation logic
+    result = {
+        'date': date,
+        'time': time,
+        'place': place,
+        'message': 'Astro calculation placeholder'
+    }
+    print(json.dumps(result))
+
+if __name__ == '__main__':
+    main()

--- a/vedic-astroloji-hesaplayici/includes/python/astro_calc_test.py
+++ b/vedic-astroloji-hesaplayici/includes/python/astro_calc_test.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+import subprocess, json
+
+def test():
+    result = subprocess.check_output(['python3', 'astro_calc.py', '2023-01-01', '12:00', 'Istanbul'])
+    data = json.loads(result)
+    assert data['date'] == '2023-01-01'
+    assert 'message' in data
+    print('ok')
+
+if __name__ == '__main__':
+    test()

--- a/vedic-astroloji-hesaplayici/templates/form-template.php
+++ b/vedic-astroloji-hesaplayici/templates/form-template.php
@@ -1,0 +1,9 @@
+<form method="post">
+    <label>Isim: <input type="text" name="name" required></label><br>
+    <label>E-posta: <input type="email" name="email"></label><br>
+    <label>Dogum Tarihi: <input type="date" name="birth_date" required></label><br>
+    <label>Dogum Saati: <input type="time" name="birth_time" required></label><br>
+    <label>Dogum Yeri: <input type="text" name="birth_place" required></label><br>
+    <input type="hidden" name="vah_form_submitted" value="1">
+    <button type="submit">Gonder</button>
+</form>

--- a/vedic-astroloji-hesaplayici/templates/report-html-template.php
+++ b/vedic-astroloji-hesaplayici/templates/report-html-template.php
@@ -1,0 +1,5 @@
+<h2>Astroloji Raporu</h2>
+<p>Dogum Tarihi: <?php echo esc_html($report['date'] ?? ''); ?></p>
+<p>Dogum Saati: <?php echo esc_html($report['time'] ?? ''); ?></p>
+<p>Dogum Yeri: <?php echo esc_html($report['place'] ?? ''); ?></p>
+<p><?php echo esc_html($report['message'] ?? ''); ?></p>

--- a/vedic-astroloji-hesaplayici/uninstall.php
+++ b/vedic-astroloji-hesaplayici/uninstall.php
@@ -1,0 +1,11 @@
+<?php
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit();
+}
+
+// Rapor postlarini sil
+$reports = get_posts(array('post_type' => 'astro_report', 'numberposts' => -1));
+foreach ($reports as $report) {
+    wp_delete_post($report->ID, true);
+}
+?>

--- a/vedic-astroloji-hesaplayici/vedic-astroloji.php
+++ b/vedic-astroloji-hesaplayici/vedic-astroloji.php
@@ -1,0 +1,50 @@
+<?php
+/*
+Plugin Name: Vedik Astroloji Hesaplayici
+Description: Doğum bilgilerine göre vedik astroloji hesaplamaları yapan bir WordPress eklentisi.
+Version: 0.1.0
+Author: Codex
+*/
+
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
+}
+
+// Eklentinin dosya yolu tanımı
+if (!defined('VAH_PLUGIN_DIR')) {
+    define('VAH_PLUGIN_DIR', plugin_dir_path(__FILE__));
+}
+
+// Dahil edilecek dosyalar
+require_once VAH_PLUGIN_DIR . 'includes/post-types.php';
+require_once VAH_PLUGIN_DIR . 'includes/form-handler.php';
+require_once VAH_PLUGIN_DIR . 'includes/astro-calculator.php';
+
+// Yönetici alanı dosyaları
+if (is_admin()) {
+    require_once VAH_PLUGIN_DIR . 'includes/admin/admin-menu.php';
+}
+
+// Kısa kod
+function vah_register_shortcode() {
+    ob_start();
+    include VAH_PLUGIN_DIR . 'templates/form-template.php';
+    return ob_get_clean();
+}
+add_shortcode('vedic_astro_form', 'vah_register_shortcode');
+
+// Stil ve scriptler
+function vah_enqueue_assets() {
+    wp_enqueue_style('vah-style', plugins_url('assets/css/style.css', __FILE__));
+    wp_enqueue_script('vah-script', plugins_url('assets/js/script.js', __FILE__), array('jquery'), null, true);
+}
+add_action('wp_enqueue_scripts', 'vah_enqueue_assets');
+
+// Yönetici stil ve scriptleri
+function vah_admin_assets($hook) {
+    wp_enqueue_style('vah-admin-style', plugins_url('assets/css/admin-style.css', __FILE__));
+    wp_enqueue_script('vah-admin-script', plugins_url('assets/js/admin-script.js', __FILE__), array('jquery'), null, true);
+}
+add_action('admin_enqueue_scripts', 'vah_admin_assets');
+
+?>


### PR DESCRIPTION
## Summary
- introduce `vedic-astroloji-hesaplayici` WordPress plugin
- implement simple form handling and astro report storage
- add placeholder Python astro calculator
- include admin menu and basic settings page
- add CSS/JS assets and templates

## Testing
- `python3 vedic-astroloji-hesaplayici/includes/python/astro_calc_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68654b5fe14c832f8c9978918470ada0